### PR TITLE
✨ [Feature] 홈화면 페이지 조회 API 및 Redis 캐시 적용

### DIFF
--- a/src/main/java/com/example/harumeonglog/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/controller/PostController.java
@@ -158,4 +158,15 @@ public class PostController {
         return CustomResponse.ok(postPreviewListResponse);
     }
 
+    @Operation(summary = "각 카테고리별 첫 번째 게시물 조회 (홈 화면) API by 김준환", description = "게시물 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    @GetMapping("/categories")
+    public CustomResponse<PostResponse.HomePostListRequest> getHomePosts(
+    ) {
+        PostResponse.HomePostListRequest homePostListRequest = postQueryService.getHomePosts();
+        return CustomResponse.ok(homePostListRequest);
+    }
+
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/converter/PostConverter.java
@@ -86,4 +86,21 @@ public class PostConverter {
                 .createAt(post.getCreatedAt())
                 .build();
     }
+
+    public static PostResponse.HomePostListRequest toHomePostListRequest(List<Post> postList) {
+
+        List<PostResponse.HomePostRequest> homePostList = postList.stream().map(PostConverter::toHomePostRequest).toList();
+
+        return PostResponse.HomePostListRequest.builder()
+                .homePostRequestList(homePostList)
+                .build();
+    }
+
+    private static PostResponse.HomePostRequest toHomePostRequest(Post post) {
+
+        return PostResponse.HomePostRequest.builder()
+                .postCategory(post.getCategory())
+                .title(post.getTitle())
+                .build();
+    }
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/dto/response/PostResponse.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/dto/response/PostResponse.java
@@ -77,4 +77,21 @@ public class PostResponse {
         private LocalDateTime updateAt;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class HomePostListRequest {
+        private List<HomePostRequest> homePostRequestList;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class HomePostRequest {
+        private PostCategory postCategory;
+        private String title;
+    }
+
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/repository/PostRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("select p " +
@@ -31,4 +33,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "from Post p join PostLike pl on pl.post = p join fetch p.member m " +
             "where pl.member = :member and p.deletedAt is null and p.id < :cursor order by p.id desc")
     Slice<Post> findMyLikePosts(Member member, Long cursor, Pageable pageable);
+
+    @Query(value = """
+        SELECT * FROM (
+            SELECT *, ROW_NUMBER() OVER (PARTITION BY category ORDER BY created_at DESC) as rn
+            FROM post
+        ) AS ranked
+        WHERE rn = 1
+    """, nativeQuery = true)
+    List<Post> findFirstPostsByAllCategory();
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryService.java
@@ -15,4 +15,6 @@ public interface PostQueryService {
     PostResponse.PostPreviewListResponse getMyPost(Long cursor, Integer size, Member member);
 
     PostResponse.PostPreviewListResponse getMyLikePost(Long cursor, Integer size, Member member);
+
+    PostResponse.HomePostListRequest getHomePosts();
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -77,6 +77,13 @@ public class PostQueryServiceImpl implements PostQueryService {
         return buildPostPreviewListResponse(postSlice, member);
     }
 
+    @Override
+    public PostResponse.HomePostListRequest getHomePosts() {
+        List<Post> firstPostsByAllCategory = postRepository.findFirstPostsByAllCategory();
+
+        return PostConverter.toHomePostListRequest(firstPostsByAllCategory);
+    }
+
     private Long normalizeCursor(Long cursor) {
         return (cursor == 0) ? Long.MAX_VALUE : cursor;
     }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -15,6 +15,7 @@ import com.example.harumeonglog.global.error.code.PostErrorCode;
 import com.example.harumeonglog.global.error.exception.PostException;
 import com.example.harumeonglog.global.util.S3Util;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -77,6 +78,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         return buildPostPreviewListResponse(postSlice, member);
     }
 
+    @Cacheable(cacheNames = "getHomePosts", cacheManager = "homePostsCacheManager", key = "'posts:categories'")
     @Override
     public PostResponse.HomePostListRequest getHomePosts() {
         List<Post> firstPostsByAllCategory = postRepository.findFirstPostsByAllCategory();

--- a/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
@@ -29,7 +29,7 @@ public class RedisCacheConfig {
                                 new GenericJackson2JsonRedisSerializer()
                         )
                 )
-                .entryTtl(Duration.ofMinutes(1L));
+                .entryTtl(Duration.ofMinutes(2L));
 
         return RedisCacheManager
                 .RedisCacheManagerBuilder

--- a/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
@@ -1,0 +1,42 @@
+package com.example.harumeonglog.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager homePostsCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
+                        )
+                )
+                .entryTtl(Duration.ofMinutes(1L));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+}
+


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #107 

## 📌 개요
- 홈화면 페이지 조회 API 추가

## 🔁 변경 사항 
- 홈화면 페이지 조회 API 추가
[✨ feature: 카테고리별 첫 번째 게시물 조회 기능 추가](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/8cc907aed7ab6288e414667e53a7385a4032d65d)
[⚡ perf: redis cache 적용](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/9caefa95f0a6e4c28a375b49e845c70d1263b557)

## 📸 스크린샷 (Optional)
### 홈화면 페이지 조회 Redis 적용 시 부하 테스트 (게시물 10만건 기준, 가상 유저 30명, 지속 시간 30초, 동일 인프라 기준)

- 적용 전 <br>
<img width="757" alt="스크린샷 2025-06-01 오후 8 29 02" src="https://github.com/user-attachments/assets/1bea1fdb-603e-4bc8-9828-044459379f64" /> <br>

- 적용 후 <br>
<img width="750" alt="스크린샷 2025-06-01 오후 8 28 53" src="https://github.com/user-attachments/assets/74d8e5fc-015c-47d8-a5ac-65c75b6c33e1" /> <br>


초당 처리량(Throughput)이 2.34건에서 111.96건으로 향상되어, 약 48배의 성능 개선이 이루어졌습니다.

## 👀 기타 더 이야기해볼 점 (Optional)
- 현재 홈화면에 들어가는 첫번째 게시판의 경우 최신성을 고려하여 TTL을 2분으로 하였습니다. 이에 대해서는 어떻게 생각하시는 지 궁금합니다.
- 다른 게시판 조회의 경우에도 시간이 오래 걸려서 개선이 필요해보이는 데 이에 대한 적용은 어떻게 생각하시는 지 궁금합니다

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
