### PR TITLE
🐛 [Fix] 게시물 좋아요 동시성 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
     mavenCentral()
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -54,6 +58,7 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux';
@@ -64,6 +69,8 @@ dependencies {
 
     // fcm
     implementation 'com.google.firebase:firebase-admin:9.1.0'
+
+    testImplementation 'com.h2database:h2'
 }
 
 jar {

--- a/src/main/java/com/example/harumeonglog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/repository/PostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -42,4 +43,16 @@ public interface PostRepository extends JpaRepository<Post, Long> {
         WHERE rn = 1
     """, nativeQuery = true)
     List<Post> findFirstPostsByAllCategory();
+
+    @Query(value = """
+        UPDATE Post p SET p.postLikeNum = p.postLikeNum + 1 WHERE p = :post
+    """)
+    @Modifying
+    void updatePostLikeNumByPost(Post post);
+
+    @Query(value = """
+        UPDATE Post p SET p.postLikeNum = p.postLikeNum - 1 WHERE p = :post
+    """)
+    @Modifying
+    void updatePostUnLikeNumByPost(Post post);
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -69,11 +69,11 @@ public class PostCommandServiceImpl implements PostCommandService {
 
         PostLike postLike = postLikeRepository.findByPostAndMember(post, member);
         if (postLike != null) {
-            post.fixLikeNum(-1L);
             postLikeRepository.delete(postLike);
+            postRepository.updatePostUnLikeNumByPost(post);
         } else {
-            post.fixLikeNum(1L);
             postLikeRepository.save(PostLikeConverter.toPostLike(post, member));
+            postRepository.updatePostLikeNumByPost(post);
         }
     }
 

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -70,6 +70,7 @@ public class PostCommandServiceImpl implements PostCommandService {
         PostLike postLike = postLikeRepository.findByPostAndMember(post, member);
         if (postLike != null) {
             postLikeRepository.delete(postLike);
+            postLikeRepository.flush();
             postRepository.updatePostUnLikeNumByPost(post);
         } else {
             postLikeRepository.save(PostLikeConverter.toPostLike(post, member));

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -70,7 +70,6 @@ public class PostCommandServiceImpl implements PostCommandService {
         PostLike postLike = postLikeRepository.findByPostAndMember(post, member);
         if (postLike != null) {
             postLikeRepository.delete(postLike);
-            postLikeRepository.flush();
             postRepository.updatePostUnLikeNumByPost(post);
         } else {
             postLikeRepository.save(PostLikeConverter.toPostLike(post, member));

--- a/src/test/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImplTest.java
@@ -14,10 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -156,5 +159,63 @@ class PostCommandServiceImplTest {
                 "좋아요 수가 비정상적으로 계산되었습니다."
         );
     }
-  
+
+    @Test
+    @DisplayName("여러 명이 동시에 하나의 게시글을 좋아요할 때 동시성 문제 없이 정확히 처리되는가")
+    void concurrencyMultiMemberLikeTest() throws InterruptedException {
+        // given
+        Member writer = Member.builder()
+                .email("example@example.com")
+                .nickname("example")
+                .providerId("example")
+                .socialType(SocialType.KAKAO).build();
+
+        memberRepository.save(writer);
+
+        Post post = postRepository.save(
+                Post.builder()
+                        .category(PostCategory.INFO)
+                        .content("내용")
+                        .title("제목")
+                        .member(writer)
+                        .postLikeNum(0L)
+                        .build()
+        );
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        List<Member> members = IntStream.range(0, threadCount)
+                .mapToObj(i -> Member.builder()
+                        .email("user" + i + "@test.com")
+                        .nickname("user" + i)
+                        .providerId("provider" + i)
+                        .socialType(SocialType.KAKAO)
+                        .build())
+                .map(memberRepository::save)
+                .collect(Collectors.toList());
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            final int idx = i;
+            executorService.execute(() -> {
+                try {
+                    postCommandService.likePost(post.getId(), members.get(idx));
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+        System.out.println("최종 좋아요 수: " + updatedPost.getPostLikeNum());
+
+        assertEquals(threadCount, updatedPost.getPostLikeNum());
+    }
+
+
 }

--- a/src/test/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImplTest.java
@@ -4,13 +4,17 @@ import com.example.harumeonglog.domain.member.entity.Member;
 import com.example.harumeonglog.domain.member.entity.enums.SocialType;
 import com.example.harumeonglog.domain.member.repository.MemberRepository;
 import com.example.harumeonglog.domain.post.entity.Post;
+import com.example.harumeonglog.domain.post.entity.PostLike;
 import com.example.harumeonglog.domain.post.entity.enums.PostCategory;
+import com.example.harumeonglog.domain.post.repository.PostLikeRepository;
 import com.example.harumeonglog.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,8 +33,83 @@ class PostCommandServiceImplTest {
 
     @Autowired
     private PostCommandService postCommandService;
+    @Autowired
+    private PostLikeRepository postLikeRepository;
 
     @Test
+    @DisplayName("게시글 좋아요 수가 정상적으로 증가한다")
+    void postLikeTest() {
+        // given
+        Member member = memberRepository.save(
+                Member.builder()
+                        .email("example@example.com")
+                        .nickname("example")
+                        .providerId("example")
+                        .socialType(SocialType.KAKAO)
+                        .build()
+        );
+
+        Post post = postRepository.save(
+                Post.builder()
+                        .category(PostCategory.INFO)
+                        .content("내용")
+                        .title("제목")
+                        .member(member)
+                        .postLikeNum(0L)
+                        .build()
+        );
+
+        // when
+        postCommandService.likePost(post.getId(), member);
+
+        // then
+        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+        assertEquals(1L, updatedPost.getPostLikeNum());
+
+        // 로그 확인용
+        System.out.println("최종 좋아요 수: " + updatedPost.getPostLikeNum());
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 수가 정상적으로 감소한다")
+    void postUnLikeTest() {
+        // given
+        Member member = memberRepository.save(
+                Member.builder()
+                        .email("example@example.com")
+                        .nickname("example")
+                        .providerId("example")
+                        .socialType(SocialType.KAKAO)
+                        .build()
+        );
+
+        Post post = postRepository.save(
+                Post.builder()
+                        .category(PostCategory.INFO)
+                        .content("내용")
+                        .title("제목")
+                        .member(member)
+                        .postLikeNum(1L)
+                        .build()
+        );
+
+        postLikeRepository.save(
+                PostLike.builder()
+                        .member(member)
+                        .post(post)
+                        .build()
+        );
+
+        // when
+        postCommandService.likePost(post.getId(), member);
+
+        // then
+        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+        assertEquals(0L, updatedPost.getPostLikeNum());
+    }
+
+    @Test
+    @DisplayName("한 명이 한번에 여러 번의 좋아요를 눌렀을 때 원자적으로 처리가 되는가")
     void concurrencyLikeTest() throws InterruptedException {
         // given
         Member member = Member.builder()

--- a/src/test/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImplTest.java
+++ b/src/test/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.example.harumeonglog.domain.post.service;
+
+import com.example.harumeonglog.domain.member.entity.Member;
+import com.example.harumeonglog.domain.member.entity.enums.SocialType;
+import com.example.harumeonglog.domain.member.repository.MemberRepository;
+import com.example.harumeonglog.domain.post.entity.Post;
+import com.example.harumeonglog.domain.post.entity.enums.PostCategory;
+import com.example.harumeonglog.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class PostCommandServiceImplTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostCommandService postCommandService;
+
+    @Test
+    void concurrencyLikeTest() throws InterruptedException {
+        // given
+        Member member = Member.builder()
+                .email("example@example.com")
+                .nickname("example")
+                .providerId("example")
+                .socialType(SocialType.KAKAO).build();
+
+        Member savedMember = memberRepository.save(member);
+
+        Post post = Post.builder()
+                .category(PostCategory.INFO)
+                .content("내용")
+                .title("제목")
+                .member(savedMember)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    postCommandService.likePost(savedPost.getId(), savedMember);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+        System.out.println("최종 좋아요 수: " + updatedPost.getPostLikeNum());
+
+        // 좋아요 수가 0 또는 1이 아니면 동시성 문제 발생 가능
+        assertTrue(
+                updatedPost.getPostLikeNum() == 0L || updatedPost.getPostLikeNum() == 1L,
+                "좋아요 수가 비정상적으로 계산되었습니다."
+        );
+    }
+  
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,71 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: ${LOCAL_DB_URL}
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PW}
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        default_batch_fetch_size: 500
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  devtools:
+    restart:
+      enabled: false
+
+  output:
+    ansi:
+      enabled: always
+
+  firebase:
+    config: ${FIRE_BASE_CONFIG}
+
+jwt:
+  secret: ${JWT_SECRET}
+  time:
+    access: 3600000
+    refresh: 2592000000
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    enabled: true
+    authentication:
+      username: ${LOCAL_SWAGGER_USERNAME}
+      password: ${LOCAL_SWAGGER_PW}
+      profile-scope:
+        - dev
+
+discord:
+  web-hook-url: ${DISCORD_WEBHOOK_URL}
+
+s3:
+  bucket: ${AWS_BUCKET}
+  region: ap-northeast-2
+  access-key: ${AWS_ACCESS_KEY_ID}
+  secret-key: ${AWS_SECRET_ACCESS_KEY}
+
+cors:
+  urls:
+    - http://localhost:8080
+    - http://localhost:3000
+    - http://localhost:5500
+    - http://localhost:5501
+    - http://localhost:3453
+    - http://localhost:8800
+  methods:
+    - GET
+    - POST
+    - PUT
+    - PATCH
+    - DELETE


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #111 

## 📌 개요
- 게시물 좋아요 동시성 문제 해결

## 🔁 변경 사항 
- 게시물 좋아요 동시성 문제 해결
[🧪 test: 게시물 좋아요 동시성 테스트 코드](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/ad818bb37c2226d4aec9e4b7bd11eb234e9baba7)
[🧪 test: 게시물 좋아요 제대로 작동하는 지 테스트 코드](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/c189ae310b5171da098f70dfe4a4950cd7956aeb)
[🐛 fix: 게시물 좋아요 동시성 해결](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/372923c0e1a34294fc59dc8f5b09dd9c2bb114ea)
[🧪 test: 여러 명이 동시에 하나의 게시글을 좋아요 할 때 동시성 문제 없이 정확히 처리되는 지에 대한 테스트 코드](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/112/commits/f6d56031886d78507873f7f0cb06d43dc33b158f)

## 📸 스크린샷 (Optional)
게시물 좋아요 시 조회하고 숫자를 1 더해주는 형식이라 동시성 문제가 생겼습니다.
그래서 숫자 올리는 것을 원자성을 보장해주는 증분 쿼리로 바꿔 해당 문제를 해결하였습니다. <br>

- 적용 전 <br>
<img width="173" alt="스크린샷 2025-06-05 오후 10 00 23" src="https://github.com/user-attachments/assets/53fef5d6-84e6-4e56-a366-90667461125c" /> <br>

적용 전에는 동시성에 관한 테스트 코드는 모두 실패하였습니다 <br>
<img width="788" alt="스크린샷 2025-06-05 오후 10 37 39" src="https://github.com/user-attachments/assets/0fee2312-2197-4cd7-860a-c0ff88070041" />

- 적용 후 <br>
<img width="118" alt="스크린샷 2025-06-05 오후 10 19 05" src="https://github.com/user-attachments/assets/7c379382-2c68-4fc4-b989-2bba8f95b1d1" /> <br>

적용한 테스트 코드 또한 모두 통과하였습니다 <br>
<img width="744" alt="스크린샷 2025-06-05 오후 10 36 20" src="https://github.com/user-attachments/assets/e0439ca9-86e6-4042-b90e-a4544dc60931" />

## 👀 기타 더 이야기해볼 점 (Optional)
- 낙관적락, 비낙관적락, 분산락, 증분 쿼리, 레디스 싱글 스레드에서 가져오는 형식 중 어느 것이 가장 효과적인 지 알 수 없어 시험이 끝난 후 부하 테스트를 진행할 예정 입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
