### PR TITLE
🔨 [Refactor] postquery 리펙토링

### DIFF
--- a/src/main/java/com/example/harumeonglog/domain/post/controller/enums/PostRequestCategory.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/controller/enums/PostRequestCategory.java
@@ -1,5 +1,7 @@
 package com.example.harumeonglog.domain.post.controller.enums;
 
+import com.example.harumeonglog.domain.post.entity.enums.PostCategory;
+
 public enum PostRequestCategory {
     INFO, // 정보 공유
     HUMOR, // 유머
@@ -11,5 +13,9 @@ public enum PostRequestCategory {
 
     public boolean isAll() {
         return ALL.equals(this);
+    }
+
+    public PostCategory toPostCategory() {
+        return PostCategory.valueOf(this.name());
     }
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/controller/enums/PostRequestCategory.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/controller/enums/PostRequestCategory.java
@@ -7,4 +7,9 @@ public enum PostRequestCategory {
     SNS, // SNS
     ETC, // 기타
     ALL // 전부
+    ;
+
+    public boolean isAll() {
+        return ALL.equals(this);
+    }
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -53,10 +53,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     @Override
     public PostResponse.PostDetailResponse getPost(Member owner,Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(PostErrorCode.NOT_FOUND));
-        List<String> postImageList = post.getPostImageList().stream()
-                .map((p)->s3Util.getUrlFromKey(p.getPostImageKeyName()))
-                .toList();
-
+        List<String> postImageList = extractImageKeyName(post);
         Boolean isLiked = postLikeRepository.existsByPostAndMember(post, owner);
 
         return PostConverter.toPostDetailResponse(post, MemberConverter.toMemberInfoResponse(post.getMember(), s3Util), postImageList, isLiked);
@@ -125,5 +122,11 @@ public class PostQueryServiceImpl implements PostQueryService {
                 .toList();
 
         return PostConverter.toPostPreviewListResponse(postPreviewResponses, nextCursor, postSlice.hasNext());
+    }
+
+    private List<String> extractImageKeyName(Post post) {
+        return post.getPostImageList().stream()
+                .map((p) -> s3Util.getUrlFromKey(p.getPostImageKeyName()))
+                .toList();
     }
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -95,7 +95,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         Long nextCursor = null;
         List<Post> posts = postSlice.toList();
 
-        if (!postSlice.isLast() && !posts.isEmpty()) {
+        if (postSlice.hasNext() && posts.size() > 0) {
             nextCursor = posts.get(posts.size() - 1).getId();
         }
 

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -40,7 +40,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         search = normalizeSearch(search);
 
         Slice<Post> postSlice;
-        if (postRequestCategory.equals(PostRequestCategory.ALL)) {
+        if (postRequestCategory.isAll()) {
             postSlice = postRepository.findByContentLikeAndIdLessThanOrderByIdDesc(search, cursor, PageRequest.of(0, size));
             return buildPostPreviewListResponse(postSlice, member);
         }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -45,7 +45,7 @@ public class PostQueryServiceImpl implements PostQueryService {
             return buildPostPreviewListResponse(postSlice, member);
         }
 
-        PostCategory postCategory = PostCategory.valueOf(postRequestCategory.name());
+        PostCategory postCategory = postRequestCategory.toPostCategory();
         postSlice = postRepository.findByPostCategoryAndContentLikeAndIdLessThanOrderByIdDesc(search, cursor, postCategory, PageRequest.of(0, size));
         return buildPostPreviewListResponse(postSlice, member);
     }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -42,11 +42,11 @@ public class PostQueryServiceImpl implements PostQueryService {
         Slice<Post> postSlice;
         if (postRequestCategory.equals(PostRequestCategory.ALL)) {
             postSlice = postRepository.findByContentLikeAndIdLessThanOrderByIdDesc(search, cursor, PageRequest.of(0, size));
-        } else {
-            PostCategory postCategory = PostCategory.valueOf(postRequestCategory.name());
-            postSlice = postRepository.findByPostCategoryAndContentLikeAndIdLessThanOrderByIdDesc(search, cursor, postCategory, PageRequest.of(0, size));
+            return buildPostPreviewListResponse(postSlice, member);
         }
 
+        PostCategory postCategory = PostCategory.valueOf(postRequestCategory.name());
+        postSlice = postRepository.findByPostCategoryAndContentLikeAndIdLessThanOrderByIdDesc(search, cursor, postCategory, PageRequest.of(0, size));
         return buildPostPreviewListResponse(postSlice, member);
     }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #127 

## 📌 개요
- postquery 리펙토링

## 🔁 변경 사항 
- postquery 리펙토링
[🔨 refactor: getPosts early return 적용](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/745d36258455ed5d946d01d23078ed089aa5514f)
[🔨 refactor: getPosts category 책임분리](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/d8bb9d94e7bb38a571fd4152609d2c55b3c2ddea)
[🔨 refactor: enum 변환 책임 부여](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/48f9259c7d28bfd4f8c5237b53fda2a7460fbe2c)
[🔨 refactor: postKeyName 분리로 추상화 단계 맞추기](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/37d930a8de84a3ba707d9520a96e2e19c61fdc5c)
[🔨 refactor: buildPostPreviewListResponse에서 부정어구 삭제](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/b10dbcf55f99190fe997924fc771f482f88d39db)

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
