### PR TITLE
🐛 [Fix] 산책 쿼리 수정

### DIFF
--- a/src/main/java/com/example/harumeonglog/domain/walk/repository/MemberWalkRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/walk/repository/MemberWalkRepository.java
@@ -3,7 +3,17 @@ package com.example.harumeonglog.domain.walk.repository;
 import com.example.harumeonglog.domain.walk.entity.MemberWalk;
 import com.example.harumeonglog.domain.walk.entity.Walk;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MemberWalkRepository extends JpaRepository<MemberWalk, Long> {
+    @Query("""
+        SELECT mw FROM MemberWalk mw JOIN FETCH mw.member m WHERE mw.id =
+        (SELECT MIN(mw2.id) FROM MemberWalk mw2 WHERE mw2.walk.id In :walks)
+    """)
+    List<MemberWalk> findMemberNicknameByWalks(@Param("walks") List<Long> walks);
+
     MemberWalk findTopByWalkOrderByCreatedAtAsc(Walk walk);
 }

--- a/src/main/java/com/example/harumeonglog/domain/walk/repository/WalkLikeRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/walk/repository/WalkLikeRepository.java
@@ -4,10 +4,18 @@ import com.example.harumeonglog.domain.member.entity.Member;
 import com.example.harumeonglog.domain.walk.entity.Walk;
 import com.example.harumeonglog.domain.walk.entity.WalkLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WalkLikeRepository extends JpaRepository<WalkLike, Long> {
     Optional<WalkLike> findByMemberAndWalk(Member member, Walk walk);
     boolean existsByMemberAndWalk(Member member, Walk walk);
+
+    @Query("""
+        SELECT wl FROM WalkLike wl JOIN FETCH wl.walk w WHERE wl.walk.id IN :walks
+    """)
+    List<WalkLike> findByWalks(@Param("walks") List<Long> walks);
 }

--- a/src/main/java/com/example/harumeonglog/domain/walk/service/WalkQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/walk/service/WalkQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.harumeonglog.domain.pet.repository.MemberPetRepository;
 import com.example.harumeonglog.domain.walk.converter.WalkConverter;
 import com.example.harumeonglog.domain.walk.dto.request.WalkRequest;
 import com.example.harumeonglog.domain.walk.dto.response.WalkResponse;
+import com.example.harumeonglog.domain.walk.entity.MemberWalk;
 import com.example.harumeonglog.domain.walk.entity.Walk;
 import com.example.harumeonglog.domain.walk.entity.enums.WalkStatus;
 import com.example.harumeonglog.domain.walk.enums.WalkSort;
@@ -101,14 +102,20 @@ public class WalkQueryServiceImpl implements WalkQueryService {
             cursor = walks.get(walks.size() - 1).getId();
         }
 
+        List<Long> walkIds = walks.stream().map(Walk::getId).toList();
         List<WalkResponse.WalkSearchResponse> responses = new ArrayList<>();
-        // FIXME: 쿼리 수정 필요 offset 만큼 쿼리 생성
+        Map<Long, String> nicknames = new HashMap<>();
+        for (MemberWalk memberWalk : memberWalkRepository.findMemberNicknameByWalks(walkIds)) {
+            nicknames.put(memberWalk.getWalk().getId(), memberWalk.getMember().getNickname());
+        }
+        List<Long> walkLikeIds = walkLikeRepository.findByWalks(walkIds)
+                .stream().map(walkLike -> walkLike.getWalk().getId()).toList();
         walks.forEach(walk ->
-            responses.add(WalkConverter.toWalkSearchResponse(
-                    walk,
-                    memberWalkRepository.findTopByWalkOrderByCreatedAtAsc(walk).getMember().getNickname(),
-                    walkLikeRepository.existsByMemberAndWalk(member, walk)
-            ))
+                responses.add(WalkConverter.toWalkSearchResponse(
+                        walk,
+                        nicknames.getOrDefault(walk.getId(), "알 수 없음"),
+                        walkLikeIds.contains(walk.getId())
+                ))
         );
 
         return WalkConverter.toWalkSearchListResponse(responses, cursor, hasNext);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #131 

## 📌 개요
- 산책 쿼리 수정

## 🔁 변경 사항 
https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/b0fe9a93e99e75db5a11236c96f50ee32ae9b816
- 산책 쿼리 수정

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

### 문제
#### 쿼리의 개수 외에도 성능에 유의미한 차이를 가지는가?
- 30명의 가상사용자로 30초의 부하를 가하는 상황을 각 케이스에 35번 적용한 결과
<img width="296" alt="Screenshot 2025-06-27 at 14 18 31" src="https://github.com/user-attachments/assets/7ddae092-74b5-419b-8686-474f64fcca0f" />

```text
해당 표는 표본의 수가 35이므로 중심극한정리에 의해 정규분포를 따른다.
두 표본은 독립된 표본으로 등분산이 아니므로 Welch's Test를 적용할 예정입니다. 두 표본에 대해 아래와 같이 귀무가설과 대립가설을 설정하고 유의수준 95%에서 양측검정을 진행하겠습니다.
H0: 이전과 이후의 성능 차이가 없다.
H1: 이전과 이후의 성능 차이가 있다.

p-value: 3.32 × 10⁻²⁷
p-value가 0.05보다 낮으므로 적용 후 유의미한 성능 차이가 있습니다. 

```

성능 차이 = ${B 평균}\over{A 평균}$ = 2.33...

$\therefore$ 적용 전에 비해 적용 후의 성능이 2.33배 가량 향상된 것을 알 수 있습니다.

### 테스트 환경
#### EC2
- Amazon Linux 2023 AMI (al2023-ami-2023.7.20250527.1-kernel-6.1-x86_64)
- t2.micro
- 2 vCpu
- 1 volume (8 GiB gp3)

#### Database
- MySQL 8.0.41
- 1 Instance
- db.t4g.micro
- Storage: gp2, 20GiB
- 2 vCPU
- RAM: 1GB

#### 부하테스트 툴
- K6
- VUs: 30
- Duration: 30s

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
