### PR TITLE
🔨 [Refactor] post api 리팩토링

### DIFF
--- a/src/main/java/com/example/harumeonglog/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/converter/PostConverter.java
@@ -6,13 +6,12 @@ import com.example.harumeonglog.domain.post.dto.request.PostRequest;
 import com.example.harumeonglog.domain.post.dto.response.PostResponse;
 import com.example.harumeonglog.domain.post.entity.Post;
 import com.example.harumeonglog.domain.post.entity.PostImage;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostConverter {
 
     public static PostResponse.PostDetailResponse toPostDetailResponse(Post post, MemberResponse.MemberInfoResponse memberInfoResponse, List<String> imageList, Boolean isLiked) {

--- a/src/main/java/com/example/harumeonglog/domain/post/converter/PostImageConverter.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/converter/PostImageConverter.java
@@ -1,7 +1,10 @@
 package com.example.harumeonglog.domain.post.converter;
 
 import com.example.harumeonglog.domain.post.entity.PostImage;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostImageConverter {
 
     public static PostImage toPostImage(String imageKeyName) {

--- a/src/main/java/com/example/harumeonglog/domain/post/converter/PostLikeConverter.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/converter/PostLikeConverter.java
@@ -3,7 +3,10 @@ package com.example.harumeonglog.domain.post.converter;
 import com.example.harumeonglog.domain.member.entity.Member;
 import com.example.harumeonglog.domain.post.entity.Post;
 import com.example.harumeonglog.domain.post.entity.PostLike;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostLikeConverter {
 
     public static PostLike toPostLike(Post post, Member member) {

--- a/src/main/java/com/example/harumeonglog/domain/post/converter/PostReportConverter.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/converter/PostReportConverter.java
@@ -3,7 +3,10 @@ package com.example.harumeonglog.domain.post.converter;
 import com.example.harumeonglog.domain.member.entity.Member;
 import com.example.harumeonglog.domain.post.entity.Post;
 import com.example.harumeonglog.domain.post.entity.PostReport;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostReportConverter {
 
     public static PostReport toPostReport(Post post, Member member) {

--- a/src/main/java/com/example/harumeonglog/domain/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/repository/PostLikeRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
-    PostLike findByPostAndMember(Post post, Member member);
+    Optional<PostLike> findByPostAndMember(Post post, Member member);
 
     Boolean existsByPostAndMember(Post post, Member member);
 

--- a/src/main/java/com/example/harumeonglog/domain/post/repository/PostReportRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/repository/PostReportRepository.java
@@ -6,6 +6,8 @@ import com.example.harumeonglog.domain.post.entity.PostLike;
 import com.example.harumeonglog.domain.post.entity.PostReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
-    PostReport findByPostAndMember(Post post, Member member);
+    Optional<PostReport> findByPostAndMember(Post post, Member member);
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -98,8 +98,8 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     private static void addImage(PostRequest.PostCreateRequest postCreateRequest, Post post) {
-        postCreateRequest.getPostImageList().forEach((s)->{
-            PostImage postImage = PostImageConverter.toPostImage(s);
+        postCreateRequest.getPostImageList().forEach(imageKeyName -> {
+            PostImage postImage = PostImageConverter.toPostImage(imageKeyName);
             post.addPostImage(postImage);
         });
     }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -86,14 +86,18 @@ public class PostCommandServiceImpl implements PostCommandService {
     public void reportPost(Long postId, Member member) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(PostErrorCode.NOT_FOUND));
 
-        PostReport postReport = postReportRepository.findByPostAndMember(post, member);
-        if (postReport != null) {
-            postReportRepository.delete(postReport);
-            postRepository.updatePostUnReportNumByPost(post);
-        } else {
-            postReportRepository.save(PostReportConverter.toPostReport(post, member));
-            postRepository.updatePostReportNumByPost(post);
-        }
+        Optional<PostReport> postReport = postReportRepository.findByPostAndMember(post, member);
+
+        postReport.ifPresentOrElse(
+                report -> {
+                    postReportRepository.delete(report);
+                    postRepository.updatePostUnReportNumByPost(post);
+                },
+                () -> {
+                    postReportRepository.save(PostReportConverter.toPostReport(post, member));
+                    postRepository.updatePostReportNumByPost(post);
+                }
+        );
     }
 
     private void isOwnPost(Member member, Post post) {

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -97,7 +97,7 @@ public class PostCommandServiceImpl implements PostCommandService {
         );
     }
 
-    private static void addImage(PostRequest.PostCreateRequest postCreateRequest, Post post) {
+    private void addImage(PostRequest.PostCreateRequest postCreateRequest, Post post) {
         postCreateRequest.getPostImageList().forEach(imageKeyName -> {
             PostImage postImage = PostImageConverter.toPostImage(imageKeyName);
             post.addPostImage(postImage);

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -67,14 +68,18 @@ public class PostCommandServiceImpl implements PostCommandService {
     public void likePost(Long postId, Member member) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(PostErrorCode.NOT_FOUND));
 
-        PostLike postLike = postLikeRepository.findByPostAndMember(post, member);
-        if (postLike != null) {
-            postLikeRepository.delete(postLike);
-            postRepository.updatePostUnLikeNumByPost(post);
-        } else {
-            postLikeRepository.save(PostLikeConverter.toPostLike(post, member));
-            postRepository.updatePostLikeNumByPost(post);
-        }
+        Optional<PostLike> postLike = postLikeRepository.findByPostAndMember(post, member);
+
+        postLike.ifPresentOrElse(
+                like -> {
+                    postLikeRepository.delete(like);
+                    postRepository.updatePostUnLikeNumByPost(post);
+                },
+                () -> {
+                    postLikeRepository.save(PostLikeConverter.toPostLike(post, member));
+                    postRepository.updatePostLikeNumByPost(post);
+                }
+        );
     }
 
     @Override

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -35,10 +35,7 @@ public class PostCommandServiceImpl implements PostCommandService {
     public PostResponse.PostCreateResponse createPost(PostRequest.PostCreateRequest postCreateRequest, Member member) {
         Post post = PostConverter.toPost(postCreateRequest, member);
 
-        postCreateRequest.getPostImageList().forEach((s)->{
-            PostImage postImage = PostImageConverter.toPostImage(s);
-            post.addPostImage(postImage);
-        });
+        addImage(postCreateRequest, post);
 
         return PostConverter.toPostCreateResponse(postRepository.save(post));
     }
@@ -98,6 +95,13 @@ public class PostCommandServiceImpl implements PostCommandService {
                     postRepository.updatePostReportNumByPost(post);
                 }
         );
+    }
+
+    private static void addImage(PostRequest.PostCreateRequest postCreateRequest, Post post) {
+        postCreateRequest.getPostImageList().forEach((s)->{
+            PostImage postImage = PostImageConverter.toPostImage(s);
+            post.addPostImage(postImage);
+        });
     }
 
     private void isOwnPost(Member member, Post post) {

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -95,7 +95,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         Long nextCursor = null;
         List<Post> posts = postSlice.toList();
 
-        if (postSlice.hasNext() && !posts.isEmpty()) {
+        if (hasNextCursor(postSlice, posts)) {
             nextCursor = posts.get(posts.size() - 1).getId();
         }
 
@@ -121,6 +121,10 @@ public class PostQueryServiceImpl implements PostQueryService {
                 .toList();
 
         return PostConverter.toPostPreviewListResponse(postPreviewResponses, nextCursor, postSlice.hasNext());
+    }
+
+    private boolean hasNextCursor(Slice<Post> postSlice, List<Post> posts) {
+        return postSlice.hasNext() && !posts.isEmpty();
     }
 
     private List<String> extractImageKeyName(Post post) {

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -129,7 +129,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private List<String> extractImageKeyName(Post post) {
         return post.getPostImageList().stream()
-                .map((p) -> s3Util.getUrlFromKey(p.getPostImageKeyName()))
+                .map(postImage -> s3Util.getUrlFromKey(postImage.getPostImageKeyName()))
                 .toList();
     }
 }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -95,7 +95,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         Long nextCursor = null;
         List<Post> posts = postSlice.toList();
 
-        if (postSlice.hasNext() && posts.size() > 0) {
+        if (postSlice.hasNext() && !posts.isEmpty()) {
             nextCursor = posts.get(posts.size() - 1).getId();
         }
 

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostQueryServiceImpl.java
@@ -99,7 +99,6 @@ public class PostQueryServiceImpl implements PostQueryService {
             nextCursor = posts.get(posts.size() - 1).getId();
         }
 
-        // ✅ 좋아요 여부를 한 번에 조회
         List<PostLike> postLikes = postLikeRepository.findByPostInAndMember(posts, member);
         Set<Long> likedPostIds = postLikes.stream()
                 .map(postLike -> postLike.getPost().getId())


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #139 

## 📌 개요
- post api refactoring

## 🔁 변경 사항 
- post api refactoring
[🔨 refactor: likePost 부정어구 삭제 및 null 안티 패턴 제](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/140/commits/fae381feeb5de008446663e27cc0d68aaa388a6c)
[🔨 refactor: report 부정어구 삭제 및 null 안티 패턴 제거](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/132a53839eca461807b7f92bd2ed07e798019c80)
[🔨 refactor: addImage 함수 나누어 추상화 단계 맞추기](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/97d198e0fbe5e64cf8847b40d0a0584aa928bd12)
[🔨 refactor: 소괄호 제거 및 풀네임 작성](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/d2af8c331cdb3bbcd0860383346e9fd8f4803c91)
[🔨 refactor: nextCursor 유무 리펙토](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/140/commits/7e27f578d65414dc456558ed5e45e9f0b4b0358b)
[🔨 refactor: nextCursor 유무 메서드로 추](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/140/commits/094b31f580bc9a36d559033e286ce945a18dec41)
[🔨 refactor: keyName 추출 메서드 변수 풀네임으로 교체](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/140/commits/f0df7afcd30216602e25cb0bc1483b9d2408716d)
[🔨 refactor: util 클래스 생성자 private 로 변경](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/140/commits/d4b71e1aac6f615861d1f5237051008acaa45abe)
[🔨 refactor: post 관련 util 클래스 생성자 private 로 변경](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/140/commits/1675f0987f2c67d89d5083dc9b1b6d0c648a21b6)

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
