### PR TITLE
🚀 [Chore] 비동기 쓰레드 수 조정

### DIFF
--- a/src/main/java/com/example/harumeonglog/domain/comment/service/CommentCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/comment/service/CommentCommandServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.harumeonglog.global.error.code.CommentErrorCode;
 import com.example.harumeonglog.global.error.code.PostErrorCode;
 import com.example.harumeonglog.global.error.exception.CommentException;
 import com.example.harumeonglog.global.error.exception.PostException;
+import com.example.harumeonglog.global.firebase.converter.FCMConverter;
 import com.example.harumeonglog.global.firebase.service.FcmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -121,7 +122,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
             String title = "댓글 좋아요";
             String body = member.getNickname() + "님이 회원님의 댓글을 좋아합니다.";
-            fcmService.sendPushNotification(comment.getMember(), title, body, NoticeType.COMMENT);
+            fcmService.sendPushNotification(FCMConverter.toReceiverRequest(comment.getMember()), title, body, NoticeType.COMMENT);
             noticeCommandService.createNotice(title, body, NoticeType.COMMENT, member, comment.getMember());
         }
 

--- a/src/main/java/com/example/harumeonglog/domain/event/scheduler/EventScheduler.java
+++ b/src/main/java/com/example/harumeonglog/domain/event/scheduler/EventScheduler.java
@@ -7,6 +7,7 @@ import com.example.harumeonglog.domain.member.entity.Setting;
 import com.example.harumeonglog.domain.member.entity.enums.NoticeType;
 import com.example.harumeonglog.domain.member.repository.SettingRepository;
 import com.example.harumeonglog.domain.member.service.NoticeCommandService;
+import com.example.harumeonglog.global.firebase.converter.FCMConverter;
 import com.example.harumeonglog.global.firebase.service.FcmService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -122,7 +123,7 @@ public class EventScheduler {
             String summaryMessage = createDailySummaryMessage(events);
             String title = "오늘의 일정";
 
-            fcmService.sendPushNotification(member, title, summaryMessage, NoticeType.EVENT);
+            fcmService.sendPushNotification(FCMConverter.toReceiverRequest(member), title, summaryMessage, NoticeType.EVENT);
 
             noticeCommandService.createNotice(title, summaryMessage, NoticeType.EVENT, null, member);
 
@@ -151,7 +152,7 @@ public class EventScheduler {
             String message = createReminderMessage(event);
             String title = "일정 알림: " + event.getTitle();
 
-            fcmService.sendPushNotification(event.getMember(), title, message, NoticeType.EVENT);
+            fcmService.sendPushNotification(FCMConverter.toReceiverRequest(event.getMember()), title, message, NoticeType.EVENT);
 
             noticeCommandService.createNotice(title, message, NoticeType.EVENT, null, event.getMember());
 

--- a/src/main/java/com/example/harumeonglog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/harumeonglog/domain/member/repository/MemberRepository.java
@@ -45,8 +45,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<String> findAllImageKeys();
 
     @Modifying
-    @Query("UPDATE Member m set m.deviceId = null where m = :member")
-    void updateDeviceIdByMember(Member member);
+    @Query("UPDATE Member m set m.deviceId = null where m.id = :memberId")
+    void updateDeviceIdByMemberId(Long memberId);
 
 
     @Modifying

--- a/src/main/java/com/example/harumeonglog/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/example/harumeonglog/domain/member/service/MemberCommandService.java
@@ -10,7 +10,7 @@ public interface MemberCommandService {
 
     void saveFCM(Member member, MemberRequest.FCMRequest fcmRequest);
 
-    void notDeadLockFcmSignOut(Member member);
+    void notDeadLockFcmSignOut(Long memberId);
 
     Member changeMemberTerms(Member member, MemberRequest.MemberTermsUpdateRequest request);
 }

--- a/src/main/java/com/example/harumeonglog/domain/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/member/service/MemberCommandServiceImpl.java
@@ -63,7 +63,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
-    public void notDeadLockFcmSignOut(Member member) {
-        memberRepository.updateDeviceIdByMember(member);
+    public void notDeadLockFcmSignOut(Long member) {
+        memberRepository.updateDeviceIdByMemberId(member);
     }
 }

--- a/src/main/java/com/example/harumeonglog/domain/pet/service/command/PetCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/pet/service/command/PetCommandServiceImpl.java
@@ -22,6 +22,7 @@ import com.example.harumeonglog.global.error.code.S3ErrorCode;
 import com.example.harumeonglog.global.error.exception.MemberException;
 import com.example.harumeonglog.global.error.exception.PetException;
 import com.example.harumeonglog.global.error.exception.S3Exception;
+import com.example.harumeonglog.global.firebase.converter.FCMConverter;
 import com.example.harumeonglog.global.firebase.service.FcmService;
 import com.example.harumeonglog.global.util.OutboxUtil;
 import com.example.harumeonglog.global.util.S3Util;
@@ -195,7 +196,7 @@ public class PetCommandServiceImpl implements PetCommandService {
             String title = "[초대 알림]";
             String body = String.format("%s에 초대되었습니다.", pet.getName());
 
-            fcmService.sendPushNotification(invitedMember, title, body, NoticeType.NOTICE);
+            fcmService.sendPushNotification(FCMConverter.toReceiverRequest(invitedMember), title, body, NoticeType.NOTICE);
             noticeCommandService.createNotice(title, body, NoticeType.NOTICE, member, invitedMember);
         }
     }

--- a/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/service/PostCommandServiceImpl.java
@@ -20,6 +20,7 @@ import com.example.harumeonglog.global.error.code.PostErrorCode;
 import com.example.harumeonglog.global.error.code.S3ErrorCode;
 import com.example.harumeonglog.global.error.exception.PostException;
 import com.example.harumeonglog.global.error.exception.S3Exception;
+import com.example.harumeonglog.global.firebase.converter.FCMConverter;
 import com.example.harumeonglog.global.firebase.service.FcmService;
 import com.example.harumeonglog.global.util.OutboxUtil;
 import com.example.harumeonglog.global.util.S3Util;
@@ -117,7 +118,7 @@ public class PostCommandServiceImpl implements PostCommandService {
 
                     String title = "게시글 좋아요";
                     String body = member.getNickname() + "님이 회원님의 게시글을 좋아합니다.";
-                    fcmService.sendPushNotification(post.getMember(), title, body, NoticeType.ARTICLE);
+                    fcmService.sendPushNotification(FCMConverter.toReceiverRequest(post.getMember()), title, body, NoticeType.ARTICLE);
                     noticeCommandService.createNotice(title, body, NoticeType.ARTICLE, member, post.getMember());
                 }
         );

--- a/src/main/java/com/example/harumeonglog/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/harumeonglog/global/config/AsyncConfig.java
@@ -19,10 +19,10 @@ public class AsyncConfig implements AsyncConfigurer {
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
-        executor.setCorePoolSize(5);           // 기본 스레드 수
-        executor.setMaxPoolSize(10);           // 최대 스레드 수
-        executor.setQueueCapacity(100);        // 대기열 크기
-        executor.setThreadNamePrefix("Async-"); // 스레드 이름 prefix
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(6);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("Async-FCM-");
 
         executor.initialize();
         return executor;

--- a/src/main/java/com/example/harumeonglog/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/harumeonglog/global/config/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.example.harumeonglog.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Slf4j
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate discordRestTemplate(RestTemplateBuilder builder) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(3));
+        factory.setReadTimeout(Duration.ofSeconds(10));
+
+        return builder
+                .requestFactory(() -> factory)
+                .build();
+    }
+}

--- a/src/main/java/com/example/harumeonglog/global/discord/DiscordApiUtil.java
+++ b/src/main/java/com/example/harumeonglog/global/discord/DiscordApiUtil.java
@@ -5,12 +5,14 @@ import com.example.harumeonglog.global.discord.dto.DiscordMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class DiscordApiUtil {
 
     private final RestTemplate discordRestTemplate;
@@ -34,11 +36,10 @@ public class DiscordApiUtil {
             );
 
             if (response.getStatusCode() != HttpStatus.NO_CONTENT) {
-                throw new RuntimeException("Failed to send Discord message: " + response.getStatusCode());
+                log.warn("Discord send failed: {}", response.getStatusCode());
             }
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Failed to send Discord message", e);
+            log.warn("Discord send error", e);
         }
     }
 }

--- a/src/main/java/com/example/harumeonglog/global/discord/DiscordApiUtil.java
+++ b/src/main/java/com/example/harumeonglog/global/discord/DiscordApiUtil.java
@@ -13,8 +13,8 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class DiscordApiUtil {
 
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RestTemplate discordRestTemplate;
+    private final ObjectMapper objectMapper;
     private final DiscordConfigData discordConfigData;
 
     public void sendAlarm(DiscordMessage discordMessage) {
@@ -26,7 +26,12 @@ public class DiscordApiUtil {
 
             HttpEntity<String> request = new HttpEntity<>(jsonMessage, headers);
 
-            ResponseEntity<String> response = restTemplate.exchange(discordConfigData.getWebHookUrl(), HttpMethod.POST, request, String.class);
+            ResponseEntity<String> response = discordRestTemplate.exchange(
+                    discordConfigData.getWebHookUrl(),
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
 
             if (response.getStatusCode() != HttpStatus.NO_CONTENT) {
                 throw new RuntimeException("Failed to send Discord message: " + response.getStatusCode());

--- a/src/main/java/com/example/harumeonglog/global/firebase/converter/FCMConverter.java
+++ b/src/main/java/com/example/harumeonglog/global/firebase/converter/FCMConverter.java
@@ -1,0 +1,15 @@
+package com.example.harumeonglog.global.firebase.converter;
+
+import com.example.harumeonglog.domain.member.entity.Member;
+import com.example.harumeonglog.global.firebase.dto.request.FCMSendRequest.ReceiverRequest;
+
+public class FCMConverter {
+
+    public static ReceiverRequest toReceiverRequest(Member member) {
+        return ReceiverRequest.builder()
+                .receiverId(member.getId())
+                .deviceId(member.getDeviceId())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/harumeonglog/global/firebase/dto/request/FCMSendRequest.java
+++ b/src/main/java/com/example/harumeonglog/global/firebase/dto/request/FCMSendRequest.java
@@ -1,0 +1,14 @@
+package com.example.harumeonglog.global.firebase.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FCMSendRequest {
+
+    @Getter
+    @Builder
+    public static class ReceiverRequest {
+        private Long receiverId;
+        private String deviceId;
+    }
+}

--- a/src/main/java/com/example/harumeonglog/global/firebase/service/FcmService.java
+++ b/src/main/java/com/example/harumeonglog/global/firebase/service/FcmService.java
@@ -5,6 +5,9 @@ import com.example.harumeonglog.domain.member.entity.enums.NoticeType;
 import com.example.harumeonglog.domain.member.service.MemberCommandService;
 import com.example.harumeonglog.global.discord.DiscordApiUtil;
 import com.example.harumeonglog.global.discord.dto.DiscordMessage;
+import com.example.harumeonglog.global.firebase.converter.FCMConverter;
+import com.example.harumeonglog.global.firebase.dto.request.FCMSendRequest;
+import com.example.harumeonglog.global.firebase.dto.request.FCMSendRequest.ReceiverRequest;
 import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
@@ -24,7 +27,7 @@ public class FcmService {
     private final DiscordApiUtil discordApiUtil;
 
     @Async
-    public void sendPushNotification(Member receiver, String title, String body, NoticeType noticeType) {
+    public void sendPushNotification(ReceiverRequest receiver, String title, String body, NoticeType noticeType) {
         if (receiver.getDeviceId() == null) {
             return;
         }
@@ -62,8 +65,8 @@ public class FcmService {
         }
     }
 
-    private void handleFcmSendFailure(Member receiver, String title, FirebaseMessagingException e) {
-        memberCommandService.notDeadLockFcmSignOut(receiver);
+    private void handleFcmSendFailure(ReceiverRequest receiver, String title, FirebaseMessagingException e) {
+        memberCommandService.notDeadLockFcmSignOut(receiver.getReceiverId());
 
         boolean isLocalProfile = List.of(environment.getActiveProfiles()).contains("local");
         if (!isLocalProfile) {
@@ -71,7 +74,7 @@ public class FcmService {
         }
     }
 
-    private DiscordMessage buildDiscordErrorMessage(Member receiver, String title, Exception e) {
+    private DiscordMessage buildDiscordErrorMessage(ReceiverRequest receiver, String title, Exception e) {
         return DiscordMessage.builder()
                 .content("# 🚨 FCM 알림 에러 발생")
                 .embeds(List.of(
@@ -79,7 +82,7 @@ public class FcmService {
                                 .title("ℹ️ 에러 정보")
                                 .description(String.format(
                                         "%d번 회원의 FCM 토큰이 유효하지 않습니다.\n제목: %s\n에러: %s",
-                                        receiver.getId(), title, getStackTrace(e).substring(0, Math.min(1000, getStackTrace(e).length()))
+                                        receiver.getReceiverId(), title, getStackTrace(e).substring(0, Math.min(1000, getStackTrace(e).length()))
                                 ))
                                 .build()
                 ))


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #176 

## 📌 개요
- 비동기 쓰레드 수 조정

## 🔁 변경 사항 
[🚀 chore: 비동기 쓰레드 수 조정](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/commit/3d750452288b094e4c3153f02b612a1a05bffb18)
[🚀 chore: 디스코드 타임 아웃 설정](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/177/commits/195851c8dc043727c2ffdae8aa5dfcf0cea195d4)
[🚀 chore: 디스코드 에러를 로그로 변](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/177/commits/e3e50e4cc597e07f517411c251572b126569b937)
[♻️ refactor: fcm dto 생성 및 트랜잭션 분](https://github.com/Harumeonglog/Harumeonglog-ServerImpl/pull/177/commits/9b5794b244d2fa7b1d3c88d83582651754c1e7d3)

## 📸 스크린샷 (Optional)

## 👀 기타 더 이야기해볼 점 (Optional)
- IO 바운드 시 적정 쓰레드 수는 코어 수 × 2~6, FCM만 비동기 쓰레드를 쓰고 t2.micro는 1core이기에 6개로 지정
- 향후 트래픽 증감에 따라 메시지큐 추가나 쓰레드 조정이 있을 예정

- 에러 시 디스코드 알림이 나가는데 시간이 지연되면 쓰레드 부하가 생김
- 타임 아웃 설정

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
