### PR TITLE
⚡ [Perf] 어제 인기 게시물 캐시 Stampede 방지

### DIFF
--- a/src/main/java/com/example/harumeonglog/domain/post/scheduler/PostCacheScheduler.java
+++ b/src/main/java/com/example/harumeonglog/domain/post/scheduler/PostCacheScheduler.java
@@ -32,7 +32,7 @@ public class PostCacheScheduler {
 
     @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시 실행
     public void preloadYesterdayGoodPostsCache() {
-        String cacheKey = CacheKeyUtil.getYesterdayPostsCacheKey(); // 통일된 키 생성 메서드 사용
+        String cacheKey = CacheKeyUtil.getSchedulerCacheKey();
         log.info("어제 인기 게시물 캐시 Eager Preloading 시작: {} - 캐시키: {}", LocalDateTime.now(), cacheKey);
         
         try {

--- a/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
@@ -29,7 +29,7 @@ public class RedisCacheConfig {
                                 new GenericJackson2JsonRedisSerializer()
                         )
                 )
-                .entryTtl(Duration.ofHours(24L)); // 24시간 TTL로 하루 동안 캐싱
+                .entryTtl(Duration.ofHours(27L)); // 스케줄러(3시) 적재 후 다음날 키 전환(4시)까지 유효하도록 27시간
 
         return RedisCacheManager
                 .RedisCacheManagerBuilder

--- a/src/main/java/com/example/harumeonglog/global/util/CacheKeyUtil.java
+++ b/src/main/java/com/example/harumeonglog/global/util/CacheKeyUtil.java
@@ -10,63 +10,78 @@ import java.time.format.DateTimeFormatter;
 /**
  * 캐시 키 생성을 위한 유틸리티 클래스
  * 날짜 기반 캐시 키 계산 로직을 중앙화하여 일관성과 테스트 가능성 확보
+ *
+ * 스케줄러(3시)와 Cache Aside(4시)의 기준 시간이 의도적으로 분리되어 있음:
+ * - 스케줄러가 3시에 새 캐시를 미리 적재
+ * - Cache Aside는 4시에 키를 전환하여 캐시 미스 없이 새 데이터 사용
+ * - 이 1시간 간격이 Cache Stampede를 방지함
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CacheKeyUtil {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-    private static final int CACHE_REBUILD_HOUR = 3; // 새벽 3시 기준
+    private static final int SCHEDULER_REBUILD_HOUR = 3; // 스케줄러 캐시 적재 기준 시간
+    private static final int CACHE_ASIDE_HOUR = 4; // @Cacheable 키 전환 기준 시간
 
     /**
-     * 어제 인기 게시물 캐시를 위한 날짜 키 생성
-     * 
-     * 새벽 3시를 기준으로 "어제"를 계산:
-     * - 00:00 ~ 02:59: 전전날 날짜 (새벽 3시에 생성된 캐시를 계속 사용)
-     * - 03:00 ~ 23:59: 어제 날짜 (새롭게 리빌드된 캐시 사용)
-     * 
-     * 예시:
-     * - 2025-12-10 00:30 → "2025-12-08" (12월 9일 새벽 3시에 생성된 캐시)
-     * - 2025-12-10 03:00 → "2025-12-09" (12월 10일 새벽 3시에 생성된 캐시)
-     * - 2025-12-10 15:00 → "2025-12-09" (동일 캐시)
-     * 
+     * @Cacheable용 캐시 키 날짜 생성 (새벽 4시 기준)
+     *
+     * - 00:00 ~ 03:59: 전전날 날짜 (이전 캐시를 계속 사용)
+     * - 04:00 ~ 23:59: 어제 날짜 (스케줄러가 3시에 미리 적재한 캐시 사용)
+     *
      * @return yyyy-MM-dd 형식의 날짜 문자열
      */
     public static String getYesterdayPostsCacheDate() {
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = now.toLocalDate();
         int currentHour = now.getHour();
-        
-        // 새벽 3시 이전이면 전전날, 이후면 어제
-        LocalDate targetDate = (currentHour < CACHE_REBUILD_HOUR) 
-                ? today.minusDays(2) 
+
+        LocalDate targetDate = (currentHour < CACHE_ASIDE_HOUR)
+                ? today.minusDays(2)
                 : today.minusDays(1);
-        
+
         return targetDate.format(DATE_FORMATTER);
     }
 
     /**
-     * 새벽 3시 기준으로 어제 날짜를 LocalDate로 반환
+     * 스케줄러용 어제 날짜 반환 (새벽 3시 기준)
      * DB 쿼리에 사용하기 위한 메서드
-     * 
+     *
      * @return 새벽 3시 기준 어제 날짜 (LocalDate)
      */
     public static LocalDate getYesterdayDate() {
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = now.toLocalDate();
         int currentHour = now.getHour();
-        
-        // 새벽 3시 이전이면 전전날, 이후면 어제
-        return (currentHour < CACHE_REBUILD_HOUR) 
-                ? today.minusDays(2) 
+
+        return (currentHour < SCHEDULER_REBUILD_HOUR)
+                ? today.minusDays(2)
                 : today.minusDays(1);
     }
 
     /**
-     * 어제 인기 게시물 전체 캐시 키 생성
-     * 
-     * ⚠️ 중요: 이 메서드는 @Cacheable과 스케줄러 양쪽에서 모두 사용됩니다.
-     * 키 생성 로직을 절대 분리하지 마세요. 1:1 일치가 보장되어야 합니다.
-     * 
+     * 스케줄러용 캐시 키 생성 (새벽 3시 기준)
+     *
+     * 스케줄러가 3시에 이 키로 캐시를 적재하면,
+     * 4시에 @Cacheable이 같은 키로 전환되어 캐시 히트가 보장됨
+     *
+     * @return "posts:yesterday:yyyy-MM-dd" 형식의 캐시 키
+     */
+    public static String getSchedulerCacheKey() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDate today = now.toLocalDate();
+        int currentHour = now.getHour();
+
+        LocalDate targetDate = (currentHour < SCHEDULER_REBUILD_HOUR)
+                ? today.minusDays(2)
+                : today.minusDays(1);
+
+        return "posts:yesterday:" + targetDate.format(DATE_FORMATTER);
+    }
+
+    /**
+     * @Cacheable용 캐시 키 생성 (새벽 4시 기준)
+     *
      * @return "posts:yesterday:yyyy-MM-dd" 형식의 캐시 키
      */
     public static String getYesterdayPostsCacheKey() {

--- a/src/test/java/com/example/harumeonglog/domain/post/scheduler/PostCacheSchedulerTest.java
+++ b/src/test/java/com/example/harumeonglog/domain/post/scheduler/PostCacheSchedulerTest.java
@@ -68,10 +68,10 @@ class PostCacheSchedulerTest {
     }
 
     @Test
-    @DisplayName("스케줄러는 CacheKeyUtil과 동일한 키를 사용하여 캐시에 적재해야 한다")
+    @DisplayName("스케줄러는 CacheKeyUtil의 스케줄러용 키를 사용하여 캐시에 적재해야 한다")
     void shouldUseSameCacheKeyAsCacheKeyUtil() {
         // given
-        String expectedCacheKey = CacheKeyUtil.getYesterdayPostsCacheKey();
+        String expectedCacheKey = CacheKeyUtil.getSchedulerCacheKey();
         given(postRepository.findTop5PostsByDateAndLikes(any(LocalDate.class), any(Pageable.class))).willReturn(mockPosts);
         given(yesterdayPostsCacheManager.getCache("getYesterdayGoodPosts")).willReturn(cache);
 

--- a/src/test/java/com/example/harumeonglog/global/util/CacheKeyUtilTest.java
+++ b/src/test/java/com/example/harumeonglog/global/util/CacheKeyUtilTest.java
@@ -15,71 +15,76 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * CacheKeyUtil 테스트
- * 
+ *
  * 핵심 테스트 케이스:
- * 1. 새벽 3시 이전(00:00~02:59)에는 전전날 날짜 반환
- * 2. 새벽 3시 이후(03:00~23:59)에는 어제 날짜 반환
- * 3. 캐시 키 형식 검증
+ * 1. @Cacheable용: 새벽 4시 기준으로 키 전환
+ * 2. 스케줄러용: 새벽 3시 기준으로 키 생성
+ * 3. 3시~4시 사이에 스케줄러 키와 4시 이후 @Cacheable 키가 일치하는지 검증
  */
 @DisplayName("CacheKeyUtil 테스트")
 class CacheKeyUtilTest {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-    @DisplayName("새벽 3시 이전(00:00~02:59)에는 전전날 날짜를 반환한다")
+    @DisplayName("@Cacheable: 새벽 4시 이전(00:00~03:59)에는 전전날 날짜를 반환한다")
     @ParameterizedTest(name = "{0}시 → 전전날 날짜")
-    @MethodSource("provideHoursBeforeThreeAM")
-    void shouldReturnDayBeforeYesterdayWhenBeforeThreeAM(int hour) {
-        // given
-        LocalDate today = LocalDate.of(2025, 12, 10);
-        LocalDate expectedDate = today.minusDays(2); // 2025-12-08
-        
+    @MethodSource("provideHoursBeforeFourAM")
+    void shouldReturnDayBeforeYesterdayWhenBeforeFourAM(int hour) {
         // when
         String result = CacheKeyUtil.getYesterdayPostsCacheDate();
-        
+
         // then
-        // 실제 시간에 의존하므로 현재 시간이 0~2시 사이면 검증
         LocalDateTime now = LocalDateTime.now();
-        if (now.getHour() < 3) {
+        if (now.getHour() < 4) {
             String expected = now.toLocalDate().minusDays(2).format(DATE_FORMATTER);
             assertThat(result).isEqualTo(expected);
         }
     }
 
-    @DisplayName("새벽 3시 이후(03:00~23:59)에는 어제 날짜를 반환한다")
+    @DisplayName("@Cacheable: 새벽 4시 이후(04:00~23:59)에는 어제 날짜를 반환한다")
     @ParameterizedTest(name = "{0}시 → 어제 날짜")
-    @MethodSource("provideHoursAfterThreeAM")
-    void shouldReturnYesterdayWhenAfterThreeAM(int hour) {
+    @MethodSource("provideHoursAfterFourAM")
+    void shouldReturnYesterdayWhenAfterFourAM(int hour) {
         // when
         String result = CacheKeyUtil.getYesterdayPostsCacheDate();
-        
+
         // then
-        // 실제 시간에 의존하므로 현재 시간이 3시 이후면 검증
         LocalDateTime now = LocalDateTime.now();
-        if (now.getHour() >= 3) {
+        if (now.getHour() >= 4) {
             String expected = now.toLocalDate().minusDays(1).format(DATE_FORMATTER);
             assertThat(result).isEqualTo(expected);
         }
     }
 
     @Test
-    @DisplayName("캐시 키는 'posts:yesterday:yyyy-MM-dd' 형식이어야 한다")
+    @DisplayName("@Cacheable용 캐시 키는 'posts:yesterday:yyyy-MM-dd' 형식이어야 한다")
     void shouldReturnCorrectCacheKeyFormat() {
         // when
         String cacheKey = CacheKeyUtil.getYesterdayPostsCacheKey();
-        
+
         // then
         assertThat(cacheKey).startsWith("posts:yesterday:");
         assertThat(cacheKey).matches("posts:yesterday:\\d{4}-\\d{2}-\\d{2}");
     }
 
     @Test
-    @DisplayName("캐시 키는 날짜 부분을 포함해야 한다")
+    @DisplayName("스케줄러용 캐시 키는 'posts:yesterday:yyyy-MM-dd' 형식이어야 한다")
+    void shouldReturnCorrectSchedulerCacheKeyFormat() {
+        // when
+        String cacheKey = CacheKeyUtil.getSchedulerCacheKey();
+
+        // then
+        assertThat(cacheKey).startsWith("posts:yesterday:");
+        assertThat(cacheKey).matches("posts:yesterday:\\d{4}-\\d{2}-\\d{2}");
+    }
+
+    @Test
+    @DisplayName("@Cacheable용 캐시 키는 날짜 부분을 포함해야 한다")
     void shouldContainDateInCacheKey() {
         // when
         String cacheKey = CacheKeyUtil.getYesterdayPostsCacheKey();
         String dateOnly = CacheKeyUtil.getYesterdayPostsCacheDate();
-        
+
         // then
         assertThat(cacheKey).endsWith(dateOnly);
         assertThat(cacheKey).isEqualTo("posts:yesterday:" + dateOnly);
@@ -92,7 +97,7 @@ class CacheKeyUtilTest {
         String key1 = CacheKeyUtil.getYesterdayPostsCacheKey();
         String key2 = CacheKeyUtil.getYesterdayPostsCacheKey();
         String key3 = CacheKeyUtil.getYesterdayPostsCacheKey();
-        
+
         // then
         assertThat(key1)
                 .isEqualTo(key2)
@@ -104,72 +109,97 @@ class CacheKeyUtilTest {
     void shouldReturnDateInCorrectFormat() {
         // when
         String date = CacheKeyUtil.getYesterdayPostsCacheDate();
-        
+
         // then
         assertThat(date).matches("\\d{4}-\\d{2}-\\d{2}");
-        
-        // LocalDate로 파싱 가능해야 함
         assertThat(LocalDate.parse(date, DATE_FORMATTER)).isNotNull();
     }
 
-    /**
-     * 실제 로직 검증 테스트
-     * 현재 시간 기준으로 올바른 날짜를 반환하는지 검증
-     */
     @Test
-    @DisplayName("현재 시간 기준으로 올바른 캐시 날짜를 계산한다")
+    @DisplayName("현재 시간 기준으로 @Cacheable용 캐시 날짜를 올바르게 계산한다 (4시 기준)")
     void shouldCalculateCorrectCacheDateBasedOnCurrentTime() {
         // given
         LocalDateTime now = LocalDateTime.now();
         LocalDate today = now.toLocalDate();
         int currentHour = now.getHour();
-        
+
         // expected
-        LocalDate expectedDate = (currentHour < 3) 
-                ? today.minusDays(2) 
+        LocalDate expectedDate = (currentHour < 4)
+                ? today.minusDays(2)
                 : today.minusDays(1);
         String expectedDateString = expectedDate.format(DATE_FORMATTER);
-        
+
         // when
         String actualDate = CacheKeyUtil.getYesterdayPostsCacheDate();
-        
+
         // then
         assertThat(actualDate).isEqualTo(expectedDateString);
     }
 
     @Test
-    @DisplayName("새벽 3시 경계값에서 올바르게 동작한다")
-    void shouldHandleBoundaryAtThreeAM() {
+    @DisplayName("현재 시간 기준으로 스케줄러용 어제 날짜를 올바르게 계산한다 (3시 기준)")
+    void shouldCalculateCorrectYesterdayDateForScheduler() {
         // given
         LocalDateTime now = LocalDateTime.now();
-        
+        LocalDate today = now.toLocalDate();
+        int currentHour = now.getHour();
+
+        // expected
+        LocalDate expectedDate = (currentHour < 3)
+                ? today.minusDays(2)
+                : today.minusDays(1);
+
+        // when
+        LocalDate actualDate = CacheKeyUtil.getYesterdayDate();
+
+        // then
+        assertThat(actualDate).isEqualTo(expectedDate);
+    }
+
+    @Test
+    @DisplayName("3시 이후에 스케줄러 키와 @Cacheable 키가 일치해야 한다 (4시 이후)")
+    void shouldMatchSchedulerKeyAndCacheAsideKeyAfterFourAM() {
+        // when
+        String schedulerKey = CacheKeyUtil.getSchedulerCacheKey();
+        String cacheAsideKey = CacheKeyUtil.getYesterdayPostsCacheKey();
+
+        // then
+        LocalDateTime now = LocalDateTime.now();
+        if (now.getHour() >= 4) {
+            assertThat(schedulerKey).isEqualTo(cacheAsideKey);
+        }
+    }
+
+    @Test
+    @DisplayName("새벽 4시 경계값에서 올바르게 동작한다")
+    void shouldHandleBoundaryAtFourAM() {
         // when
         String cacheKey = CacheKeyUtil.getYesterdayPostsCacheKey();
-        
+
         // then
         assertThat(cacheKey).isNotNull();
         assertThat(cacheKey).isNotEmpty();
-        
-        // 3시 정각이면 어제 날짜를 사용해야 함
-        if (now.getHour() == 3) {
+
+        LocalDateTime now = LocalDateTime.now();
+        if (now.getHour() == 4) {
             String expectedDate = now.toLocalDate().minusDays(1).format(DATE_FORMATTER);
             assertThat(cacheKey).isEqualTo("posts:yesterday:" + expectedDate);
         }
     }
 
-    // 테스트 데이터 제공 메서드
-    private static Stream<Arguments> provideHoursBeforeThreeAM() {
+    private static Stream<Arguments> provideHoursBeforeFourAM() {
         return Stream.of(
                 Arguments.of(0),
                 Arguments.of(1),
-                Arguments.of(2)
+                Arguments.of(2),
+                Arguments.of(3)
         );
     }
 
-    private static Stream<Arguments> provideHoursAfterThreeAM() {
+    private static Stream<Arguments> provideHoursAfterFourAM() {
         return Stream.of(
-                Arguments.of(3),
                 Arguments.of(4),
+                Arguments.of(5),
                 Arguments.of(12),
                 Arguments.of(18),
                 Arguments.of(23)


### PR DESCRIPTION
## Summary
- 스케줄러(3시)와 @Cacheable(4시) 캐시 키 전환 기준 시간을 분리하여 Cache Stampede 방지
- 스케줄러가 1시간 먼저 캐시를 적재하므로, 키 전환 시점에 캐시 미스가 발생하지 않음
- TTL을 24시간 → 27시간으로 변경하여 키 전환 시점까지 캐시 유효성 보장

## Changes
- `CacheKeyUtil`: 스케줄러용(`getSchedulerCacheKey`, 3시 기준)과 Cache Aside용(`getYesterdayPostsCacheKey`, 4시 기준) 메서드 분리
- `PostCacheScheduler`: `getSchedulerCacheKey()` 사용으로 변경
- `RedisCacheConfig`: TTL 27시간으로 변경
- 관련 테스트 코드 수정

## Test plan
- [x] CacheKeyUtilTest 통과
- [x] PostCacheSchedulerTest 통과

closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)