### PR TITLE
🐛 [Fix] Redis 장애 시 CacheErrorHandler를 통한 DB fallback 처리

### DIFF
--- a/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/example/harumeonglog/global/config/RedisCacheConfig.java
@@ -1,7 +1,11 @@
 package com.example.harumeonglog.global.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -13,9 +17,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
+@Slf4j
 @Configuration
 @EnableCaching
-public class RedisCacheConfig {
+public class RedisCacheConfig implements CachingConfigurer {
 
     @Bean
     public CacheManager yesterdayPostsCacheManager(RedisConnectionFactory redisConnectionFactory) {
@@ -36,6 +41,35 @@ public class RedisCacheConfig {
                 .fromConnectionFactory(redisConnectionFactory)
                 .cacheDefaults(redisCacheConfiguration)
                 .build();
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new CacheErrorHandler() {
+            @Override
+            public void handleCacheGetError(RuntimeException e, Cache cache, Object key) {
+                log.warn("Redis 캐시 조회 실패, DB로 fallback - cache: {}, key: {}, error: {}",
+                        cache.getName(), key, e.getMessage());
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException e, Cache cache, Object key, Object value) {
+                log.warn("Redis 캐시 저장 실패 - cache: {}, key: {}, error: {}",
+                        cache.getName(), key, e.getMessage());
+            }
+
+            @Override
+            public void handleCacheEvictError(RuntimeException e, Cache cache, Object key) {
+                log.warn("Redis 캐시 삭제 실패 - cache: {}, key: {}, error: {}",
+                        cache.getName(), key, e.getMessage());
+            }
+
+            @Override
+            public void handleCacheClearError(RuntimeException e, Cache cache) {
+                log.warn("Redis 캐시 초기화 실패 - cache: {}, error: {}",
+                        cache.getName(), e.getMessage());
+            }
+        };
     }
 
 }


### PR DESCRIPTION
## Summary
- `RedisCacheConfig`에 `CacheErrorHandler`를 등록하여 Redis 장애 시 예외를 삼키고 DB로 fallback
- 기존에는 Redis 연결 실패 시 `@Cacheable`에서 예외가 발생하여 API가 500 에러를 반환했음
- 이제 Redis 장애 시에도 캐시를 무시하고 DB 조회로 정상 응답 가능

## Test plan
- [x] CacheKeyUtilTest 통과
- [x] PostCacheSchedulerTest 통과

closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)